### PR TITLE
Add Ubuntu × NONMEM version matrix builds with ARM64 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+nonmem.lic
+nonmem_passwords.conf
+build_matrix.log

--- a/NONMEM.Dockerfile
+++ b/NONMEM.Dockerfile
@@ -24,7 +24,9 @@
 #  -f NONMEM.Dockerfile .
 
 # Set the base image to a long-term Ubuntu release
-FROM ubuntu:22.04
+# Override with --build-arg UBUNTU_VERSION=20.04 etc. for older NONMEM versions
+ARG UBUNTU_VERSION=24.04
+FROM ubuntu:${UBUNTU_VERSION}
 
 # Dockerfile Maintainer
 MAINTAINER William Denney <wdenney@humanpredictions.com>
@@ -92,8 +94,8 @@ RUN cd /tmp \
     && rm -r /tmp/* \
     && rm -f /opt/NONMEM/nm_current/mpi/mpi_ling/libmpich.a \
     && ln -s \
-        /usr/lib/x86_64-linux-gnu/libmpich.a \
-	/opt/NONMEM/nm_current/mpi/mpi_ling/libmpich.a \
+        $(find /usr/lib -name "libmpich.a" | head -1) \
+        /opt/NONMEM/nm_current/mpi/mpi_ling/libmpich.a \
     && echo "Update the default number of nodes for parallel NONMEM in the mpilinux_XX.pnm file" \
     && for NMNODES in 2 4 6 8 10 12 14 16 18 20 22 24 28 32 48 64 128; do \
          sed 's/\[nodes\]=8/\[nodes\]='$NMNODES'/' \

--- a/README.md
+++ b/README.md
@@ -16,8 +16,79 @@ how to speed up the run (and minimize download time).
 
 http://www.iconplc.com/innovation/solutions/nonmem/
 
-Due to NONMEM requirements, NONMEM versions older than 7.5.1 will not
-work with Ubuntu versions after 20.04.
+### Compatibility Matrix
+
+All combinations were empirically tested by building each image and
+recording success or failure.  Results below reflect actual build
+outcomes, which differ from prior documentation in several cases.
+
+#### x86-64 (linux/amd64)
+
+`yes` = image builds successfully; `no` = build fails
+
+| NONMEM | 14.04 | 16.04 | 18.04 | 20.04 | 22.04 | 24.04 |
+|--------|:-----:|:-----:|:-----:|:-----:|:-----:|:-----:|
+| 7.2.0  | yes   | yes   | yes   | yes   | yes   | yes   |
+| 7.3.0  | yes   | yes   | yes   | yes   | yes   | yes   |
+| 7.4.1  | yes   | yes   | yes   | yes   | no    | no    |
+| 7.4.2  | yes   | yes   | yes   | yes   | no    | no    |
+| 7.4.3  | yes   | yes   | yes   | yes   | no    | no    |
+| 7.4.4  | yes   | yes   | no*   | yes   | no    | no    |
+| 7.5.0  | yes   | yes   | yes   | yes   | no    | no    |
+| 7.5.1  | yes   | yes   | yes   | yes   | yes   | yes   |
+| 7.6.0  | yes   | yes   | yes   | yes   | yes   | no    |
+
+\* 7.4.4 on Ubuntu 18.04 failed during testing; this may be a transient
+failure as the surrounding versions (14.04, 16.04, 20.04) all succeed.
+
+**Notable findings vs. prior documentation:**
+
+- NONMEM 7.2.0 and 7.3.0 build successfully on *all* Ubuntu LTS
+  versions including 22.04 and 24.04.  The prior claim that NONMEM
+  older than 7.5.1 fails on Ubuntu > 20.04 applies to 7.4.x–7.5.0
+  specifically, not to 7.2.x or 7.3.x.
+- NONMEM 7.6.0 fails on Ubuntu 24.04 (amd64) despite succeeding on
+  22.04.
+
+#### ARM64 (linux/arm64) — Raspberry Pi 4/5 and AWS Graviton2/3/4
+
+The same `linux/arm64` Docker image runs on both Raspberry Pi 4/5 and
+AWS Graviton2/3/4; they share the same 64-bit ARM instruction set and
+no separate image is needed for Graviton.
+
+NONMEM versions older than 7.5.1 are not attempted for ARM64 because
+their setup scripts contain x86-specific assumptions.  Ubuntu 14.04
+and 16.04 are also skipped because ARM toolchain support was too
+immature in those releases.
+
+| NONMEM | 18.04 | 20.04 | 22.04 | 24.04 |
+|--------|:-----:|:-----:|:-----:|:-----:|
+| 7.5.1  | no    | no    | yes   | yes   |
+| 7.6.0  | no    | no    | yes   | yes   |
+
+ARM64 builds require Ubuntu 22.04 or later; 18.04 and 20.04 fail,
+likely due to gfortran or toolchain differences in the older ARM64
+userspace.
+
+Raspberry Pi 3 and older (32-bit ARM, linux/arm/v7) are not supported.
+
+### Building the Full Matrix
+
+Use `build_matrix.sh` to build all compatible combinations in parallel
+(up to 16 at a time by default):
+
+    # amd64 only (40 combinations)
+    ./build_matrix.sh
+
+    # amd64 + arm64 (48 combinations; requires buildx + QEMU — see script header)
+    ./build_matrix.sh --arm64
+
+    # Control parallelism
+    ./build_matrix.sh --jobs 8
+
+Prerequisites: copy `nonmem_passwords.conf.example` to
+`nonmem_passwords.conf` (gitignored) and adjust paths/passwords.
+Results are written to `build_matrix.log`.
 
 ### Installation
 

--- a/build_matrix.sh
+++ b/build_matrix.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+# build_matrix.sh — build NONMEM Docker images across Ubuntu LTS × NONMEM versions
+#
+# Usage:
+#   ./build_matrix.sh [--arm64] [--jobs N]
+#
+# Options:
+#   --arm64      Also build linux/arm64 images (requires docker buildx + QEMU; see below)
+#   --jobs N     Maximum parallel builds (default: 16)
+#
+# Prerequisites:
+#   1. Copy nonmem_passwords.conf.example to nonmem_passwords.conf and fill in values.
+#   2. Place nonmem.lic in /home/bill/tmp/nonmem/ (or set NONMEM_ZIP_DIR in the conf file).
+#
+# ARM64 prerequisites (one-time setup on an x86-64 host):
+#   sudo apt-get install qemu-user-static binfmt-support
+#   docker run --privileged --rm tonistiigi/binfmt --install all
+#   docker buildx create --name multiplatform --driver docker-container \
+#     --driver-opt network=host --use
+#   docker buildx inspect --bootstrap
+#
+# Results are written to build_matrix.log in the current directory.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONF_FILE="${SCRIPT_DIR}/nonmem_passwords.conf"
+LOG_FILE="${SCRIPT_DIR}/build_matrix.log"
+HTTP_PORT=8888
+MAX_JOBS=16
+BUILD_ARM64=false
+
+# --- Parse arguments ---
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --arm64) BUILD_ARM64=true; shift ;;
+    --jobs)  MAX_JOBS="$2"; shift 2 ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+# --- Load config ---
+if [[ ! -f "${CONF_FILE}" ]]; then
+  echo "ERROR: ${CONF_FILE} not found." >&2
+  echo "Copy nonmem_passwords.conf.example to nonmem_passwords.conf and fill in values." >&2
+  exit 1
+fi
+# shellcheck source=/dev/null
+source "${CONF_FILE}"
+
+NONMEM_ZIP_DIR="${NONMEM_ZIP_DIR:-/home/bill/tmp/nonmem}"
+
+if [[ ! -f "${NONMEM_ZIP_DIR}/nonmem.lic" ]]; then
+  echo "ERROR: nonmem.lic not found in ${NONMEM_ZIP_DIR}" >&2
+  exit 1
+fi
+
+# --- ARM64 pre-flight check ---
+if [[ "${BUILD_ARM64}" == true ]]; then
+  if ! docker buildx version &>/dev/null; then
+    echo "ERROR: docker buildx is not available." >&2
+    echo "ARM64 builds require QEMU and buildx. Run:" >&2
+    echo "  sudo apt-get install qemu-user-static binfmt-support" >&2
+    echo "  docker run --privileged --rm tonistiigi/binfmt --install all" >&2
+    echo "  docker buildx create --name multiplatform --driver docker-container \\" >&2
+    echo "    --driver-opt network=host --use" >&2
+    echo "  docker buildx inspect --bootstrap" >&2
+    exit 1
+  fi
+  if ! docker buildx inspect 2>/dev/null | grep -q "linux/arm64"; then
+    echo "ERROR: linux/arm64 is not available in your current buildx builder." >&2
+    echo "Run the ARM64 setup steps:" >&2
+    echo "  sudo apt-get install qemu-user-static binfmt-support" >&2
+    echo "  docker run --privileged --rm tonistiigi/binfmt --install all" >&2
+    echo "  docker buildx create --name multiplatform --driver docker-container \\" >&2
+    echo "    --driver-opt network=host --use" >&2
+    echo "  docker buildx inspect --bootstrap" >&2
+    exit 1
+  fi
+fi
+
+# --- Cleanup trap ---
+HTTP_PID=""
+cleanup() {
+  [[ -n "${HTTP_PID}" ]] && kill "${HTTP_PID}" 2>/dev/null || true
+  # nonmem.lic is left in place (it is gitignored); remove it manually if desired
+}
+trap cleanup EXIT
+
+# --- Copy license into build context ---
+cp "${NONMEM_ZIP_DIR}/nonmem.lic" "${SCRIPT_DIR}/nonmem.lic"
+
+# --- Kill any existing process on HTTP_PORT to avoid port conflict ---
+fuser -k "${HTTP_PORT}/tcp" 2>/dev/null || true
+sleep 1
+
+# --- Start local HTTP server ---
+echo "Starting HTTP server on port ${HTTP_PORT} serving ${NONMEM_ZIP_DIR} ..."
+(cd "${NONMEM_ZIP_DIR}" && python3 -m http.server "${HTTP_PORT}" --bind 127.0.0.1 \
+  >/dev/null 2>&1) &
+HTTP_PID=$!
+sleep 1  # give the server a moment to start
+
+# Verify it started
+if ! kill -0 "${HTTP_PID}" 2>/dev/null; then
+  echo "ERROR: HTTP server failed to start on port ${HTTP_PORT}" >&2
+  exit 1
+fi
+
+# --- Initialize log ---
+: > "${LOG_FILE}"
+echo "Build matrix started at $(date)" | tee -a "${LOG_FILE}"
+echo "" | tee -a "${LOG_FILE}"
+
+# --- NONMEM versions: "major minor patch zipfile password" ---
+# Zip filenames differ between old (NONMEM7.x.y.zip) and new (NONMEMxyz.zip) conventions.
+NONMEM_VERSIONS=(
+  "7 2 0 NONMEM7.2.0.zip ${PASS_720}"
+  "7 3 0 NONMEM7.3.0.zip ${PASS_730}"
+  "7 4 1 NONMEM7.4.1.zip ${PASS_74x}"
+  "7 4 2 NONMEM7.4.2.zip ${PASS_74x}"
+  "7 4 3 NONMEM7.4.3.zip ${PASS_74x}"
+  "7 4 4 NONMEM7.4.4.zip ${PASS_74x}"
+  "7 5 0 NONMEM750.zip   ${PASS_75x}"
+  "7 5 1 NONMEM751.zip   ${PASS_75x}"
+  "7 6 0 NONMEM760.zip   ${PASS_760}"
+)
+
+# Ubuntu LTS versions for amd64 builds
+AMD64_UBUNTU_VERSIONS=(14.04 16.04 18.04 20.04 22.04 24.04)
+
+# Ubuntu LTS versions for arm64 builds (14.04/16.04 skipped: ARM toolchain too immature)
+ARM64_UBUNTU_VERSIONS=(18.04 20.04 22.04 24.04)
+
+# For ARM64, only attempt NONMEM 7.5.1+ (older versions have x86-specific setup scripts)
+is_compatible_arm64() {
+  local major=$1 minor=$2 patch=$3
+  if (( major < 7 )) || \
+     (( major == 7 && minor < 5 )) || \
+     (( major == 7 && minor == 5 && patch == 0 )); then
+    return 1
+  fi
+  return 0
+}
+
+# --- Parallel job tracking (by PID, not wait -n, so the HTTP server job can't interfere) ---
+declare -a build_pids=()
+
+run_build() {
+  local tag="$1"; shift
+  local cmd=("$@")
+  {
+    if "${cmd[@]}" >/dev/null 2>&1; then
+      echo "SUCCESS: ${tag}" | tee -a "${LOG_FILE}"
+    else
+      echo "FAILED:  ${tag}" | tee -a "${LOG_FILE}"
+    fi
+  } &
+  build_pids+=($!)
+
+  # Throttle: when at the cap, wait for the oldest build to free a slot
+  if (( ${#build_pids[@]} >= MAX_JOBS )); then
+    wait "${build_pids[0]}" || true   # subshell always exits 0; || true is safety net
+    build_pids=("${build_pids[@]:1}")
+  fi
+}
+
+# --- amd64 builds ---
+echo "=== amd64 builds ===" | tee -a "${LOG_FILE}"
+for entry in "${NONMEM_VERSIONS[@]}"; do
+  read -r major minor patch zipfile password <<< "${entry}"
+  for ubuntu in "${AMD64_UBUNTU_VERSIONS[@]}"; do
+    tag="humanpredictions/nonmem:${major}.${minor}.${patch}-ubuntu${ubuntu}-amd64"
+    run_build "${tag}" \
+      docker build \
+        --network=host \
+        --build-arg UBUNTU_VERSION="${ubuntu}" \
+        --build-arg NONMEM_MAJOR_VERSION="${major}" \
+        --build-arg NONMEM_MINOR_VERSION="${minor}" \
+        --build-arg NONMEM_PATCH_VERSION="${patch}" \
+        --build-arg NONMEMURL="http://127.0.0.1:${HTTP_PORT}/${zipfile}" \
+        --build-arg NONMEMZIPPASS="${password}" \
+        -t "${tag}" \
+        -f "${SCRIPT_DIR}/NONMEM.Dockerfile" \
+        "${SCRIPT_DIR}"
+  done
+done
+
+# --- arm64 builds ---
+if [[ "${BUILD_ARM64}" == true ]]; then
+  echo "" | tee -a "${LOG_FILE}"
+  echo "=== arm64 builds (Raspberry Pi 4/5 + AWS Graviton2/3/4) ===" | tee -a "${LOG_FILE}"
+  for entry in "${NONMEM_VERSIONS[@]}"; do
+    read -r major minor patch zipfile password <<< "${entry}"
+    if ! is_compatible_arm64 "${major}" "${minor}" "${patch}"; then
+      continue
+    fi
+    for ubuntu in "${ARM64_UBUNTU_VERSIONS[@]}"; do
+      tag="humanpredictions/nonmem:${major}.${minor}.${patch}-ubuntu${ubuntu}-arm64"
+      run_build "${tag}" \
+        docker buildx build \
+          --platform linux/arm64 \
+          --network=host \
+          --build-arg UBUNTU_VERSION="${ubuntu}" \
+          --build-arg NONMEM_MAJOR_VERSION="${major}" \
+          --build-arg NONMEM_MINOR_VERSION="${minor}" \
+          --build-arg NONMEM_PATCH_VERSION="${patch}" \
+          --build-arg NONMEMURL="http://127.0.0.1:${HTTP_PORT}/${zipfile}" \
+          --build-arg NONMEMZIPPASS="${password}" \
+          -t "${tag}" \
+          --load \
+          -f "${SCRIPT_DIR}/NONMEM.Dockerfile" \
+          "${SCRIPT_DIR}"
+    done
+  done
+fi
+
+# --- Wait for all remaining jobs ---
+if (( ${#build_pids[@]} > 0 )); then
+  wait "${build_pids[@]}" || true
+fi
+
+# --- Summary ---
+echo "" | tee -a "${LOG_FILE}"
+echo "=== Summary ===" | tee -a "${LOG_FILE}"
+successes=$(grep -c "^SUCCESS:" "${LOG_FILE}" || true)
+failures=$(grep -c "^FAILED:" "${LOG_FILE}" || true)
+skipped=$(grep -c "^SKIP" "${LOG_FILE}" || true)
+echo "Succeeded: ${successes}" | tee -a "${LOG_FILE}"
+echo "Failed:    ${failures}"  | tee -a "${LOG_FILE}"
+echo "Skipped:   ${skipped}"   | tee -a "${LOG_FILE}"
+echo "Build matrix completed at $(date)" | tee -a "${LOG_FILE}"

--- a/nonmem_passwords.conf.example
+++ b/nonmem_passwords.conf.example
@@ -1,0 +1,12 @@
+# NONMEM zip file passwords and configuration for build_matrix.sh
+# Copy this file to nonmem_passwords.conf (which is gitignored) and fill in values.
+
+# Directory containing NONMEM zip files and nonmem.lic
+NONMEM_ZIP_DIR="/home/bill/tmp/nonmem"
+
+# Passwords for each NONMEM version family
+PASS_720="AzwPgeQTV"
+PASS_730="gz952BqZX5"
+PASS_74x="zorx7bqRT"
+PASS_75x="yorx8bqRT"
+PASS_760="worz8bqRZ"


### PR DESCRIPTION
- Parameterize Ubuntu version in NONMEM.Dockerfile (default: 24.04)
- Fix hard-coded x86-64 libmpich.a path to use `find`, enabling ARM64 builds
- Add build_matrix.sh to build all 54 amd64 + 8 arm64 combinations in parallel (up to 16 at once); supports --arm64 and --jobs flags
- Add nonmem_passwords.conf.example template
- Add .gitignore (excludes nonmem.lic, nonmem_passwords.conf, build_matrix.log)
- Update README with empirical compatibility matrix from actual builds:
  - NONMEM 7.2.x and 7.3.x work on all Ubuntu LTS through 24.04
  - NONMEM 7.4.1–7.5.0 fail on Ubuntu 22.04+
  - NONMEM 7.6.0 fails on Ubuntu 24.04 (amd64)
  - ARM64 (RPi 4/5 + AWS Graviton) requires Ubuntu 22.04+