### PR TITLE
Switch to BuildKit bind mount for NONMEM zip; document gfortran 11 in compatibility

### DIFF
--- a/NONMEM.Dockerfile
+++ b/NONMEM.Dockerfile
@@ -1,26 +1,13 @@
-# Dockerfile to build NONMEM 7.5.1 with MPI
+# syntax=docker/dockerfile:1
+# Dockerfile to build NONMEM with MPI
 
-# Build with the following command:
-# docker build \
+# Build with the following command (place the NONMEM zip in the same directory
+# or pass --build-context nonmem_zips=/path/to/zips):
+# docker buildx build \
+#  --build-context nonmem_zips=/path/to/nonmem/zips \
 #  --build-arg NONMEMZIPPASS=[your password] \
-#  -t humanpredictions/nonmem:7.5.1-gfortran-1 \
-#  -t humanpredictions/nonmem:latest \
-#  -f NONMEM.Dockerfile .
-
-# Installation can be sped up for multiple installations (like
-# nmqual, NONMEM, and PsN) by pre-downloading required zip
-# files and then serving them from a local directory:
-#
-# wget --auth-no-challenge https://nonmem.iconplc.com/nonmem751/NONMEM751.zip
-# python3 -m http.server
-#
-# Then in a separate terminal, give your local server for the
-# NONMEMURL and NMQUALURL build arguments:
-# docker build \
-#  --build-arg NONMEMZIPPASS=[your password] \
-#  --build-arg NONMEMURL=http://example.com/NONMEM7.5.1.zip \
-#  -t humanpredictions/nonmem:7.5.1-gfortran-1 \
-#  -t humanpredictions/nonmem:latest \
+#  --build-arg NONMEM_ZIPFILE=NONMEM751.zip \
+#  -t humanpredictions/nonmem:7.5.1 \
 #  -f NONMEM.Dockerfile .
 
 # Set the base image to a long-term Ubuntu release
@@ -34,7 +21,6 @@ MAINTAINER William Denney <wdenney@humanpredictions.com>
 # Install:
 # gfortran,
 # MPI,
-# wget,
 # and unzip
 # (then clean up the image as much as possible)
 RUN apt-get update \
@@ -42,7 +28,6 @@ RUN apt-get update \
        gfortran \
        libmpich-dev \
        mpich \
-       wget \
        unzip \
     && rm -rf /var/lib/apt/lists/ \
               /var/cache/apt/archives/ \
@@ -55,23 +40,24 @@ ARG NONMEM_MINOR_VERSION=5
 ARG NONMEM_PATCH_VERSION=1
 ENV NONMEM_VERSION_NO_DOTS=${NONMEM_MAJOR_VERSION}${NONMEM_MINOR_VERSION}${NONMEM_PATCH_VERSION}
 ENV NONMEM_VERSION=${NONMEM_MAJOR_VERSION}.${NONMEM_MINOR_VERSION}.${NONMEM_PATCH_VERSION}
-ARG NONMEMURL=https://nonmem.iconplc.com/nonmem${NONMEM_VERSION_NO_DOTS}/NONMEM${NONMEM_VERSION_NO_DOTS}.zip
+ARG NONMEM_ZIPFILE=NONMEM751.zip
 ARG NONMEMZIPPASS
 
 ## Copy the current license file into the image
 COPY nonmem.lic /opt/NONMEM/nm${NONMEM_VERSION_NO_DOTS}/license/nonmem.lic
 
 ## Install NONMEM and then clean out unnecessary files to shrink
-## the image
+## the image.
+##
+## The zip file is provided via a BuildKit bind mount from the nonmem_zips
+## build context (--build-context nonmem_zips=/path/to/zips) so it never
+## appears as a layer in the final image.
 
 # the "if [ ! -d "/tmp/nm${NONMEM_VERSION_NO_DOTS}CD" ] ; then ln -s . nm${NONMEM_VERSION_NO_DOTS}CD ; fi"
 # line is for NONMEM 7.2.0
-RUN cd /tmp \
-    && wget \
-	 -nv --no-check-certificate --auth-no-challenge \
-         -O /tmp/NONMEM.zip \
-	 ${NONMEMURL} \
-    && unzip -P ${NONMEMZIPPASS} NONMEM.zip \
+RUN --mount=type=bind,from=nonmem_zips,source=${NONMEM_ZIPFILE},target=/nonmem_zip/NONMEM.zip \
+    cd /tmp \
+    && unzip -P ${NONMEMZIPPASS} /nonmem_zip/NONMEM.zip \
     && ls /tmp \
     && if [ ! -d "/tmp/nm${NONMEM_VERSION_NO_DOTS}CD" ] ; then ln -s . nm${NONMEM_VERSION_NO_DOTS}CD ; fi \
     && cd /tmp/nm${NONMEM_VERSION_NO_DOTS}CD \

--- a/README.md
+++ b/README.md
@@ -33,13 +33,10 @@ outcomes, which differ from prior documentation in several cases.
 | 7.4.1  | yes   | yes   | yes   | yes   | no    | no    |
 | 7.4.2  | yes   | yes   | yes   | yes   | no    | no    |
 | 7.4.3  | yes   | yes   | yes   | yes   | no    | no    |
-| 7.4.4  | yes   | yes   | no*   | yes   | no    | no    |
+| 7.4.4  | yes   | yes   | yes   | yes   | no    | no    |
 | 7.5.0  | yes   | yes   | yes   | yes   | no    | no    |
 | 7.5.1  | yes   | yes   | yes   | yes   | yes   | yes   |
-| 7.6.0  | yes   | yes   | yes   | yes   | yes   | no    |
-
-\* 7.4.4 on Ubuntu 18.04 failed during testing; this may be a transient
-failure as the surrounding versions (14.04, 16.04, 20.04) all succeed.
+| 7.6.0  | yes   | yes   | yes   | yes   | yes   | yes   |
 
 **Notable findings vs. prior documentation:**
 
@@ -47,8 +44,14 @@ failure as the surrounding versions (14.04, 16.04, 20.04) all succeed.
   versions including 22.04 and 24.04.  The prior claim that NONMEM
   older than 7.5.1 fails on Ubuntu > 20.04 applies to 7.4.x–7.5.0
   specifically, not to 7.2.x or 7.3.x.
-- NONMEM 7.6.0 fails on Ubuntu 24.04 (amd64) despite succeeding on
-  22.04.
+- NONMEM 7.4.x and 7.5.0 fail on Ubuntu 22.04 and 24.04 because
+  gfortran 11+ (shipped in Ubuntu 22.04) enforces stricter Fortran
+  standard compliance than gfortran 9 (Ubuntu 20.04).  The NONMEM
+  7.4.x/7.5.0 Fortran source contains constructs that gfortran 9
+  accepted but gfortran 11+ rejects as errors: index variables
+  redefined inside DO loops, rank mismatches in actual arguments, and
+  INTEGER(8)/INTEGER(4) type mismatches.  NONMEM 7.5.1 and later have
+  corrected Fortran source and compile successfully with gfortran 11+.
 
 #### ARM64 (linux/arm64) — Raspberry Pi 4/5 and AWS Graviton2/3/4
 
@@ -77,10 +80,10 @@ Raspberry Pi 3 and older (32-bit ARM, linux/arm/v7) are not supported.
 Use `build_matrix.sh` to build all compatible combinations in parallel
 (up to 16 at a time by default):
 
-    # amd64 only (40 combinations)
+    # amd64 only (54 combinations)
     ./build_matrix.sh
 
-    # amd64 + arm64 (48 combinations; requires buildx + QEMU — see script header)
+    # amd64 + arm64 (62 combinations; requires buildx + QEMU — see script header)
     ./build_matrix.sh --arm64
 
     # Control parallelism
@@ -90,17 +93,19 @@ Prerequisites: copy `nonmem_passwords.conf.example` to
 `nonmem_passwords.conf` (gitignored) and adjust paths/passwords.
 Results are written to `build_matrix.log`.
 
+The script uses BuildKit bind mounts (`--build-context
+nonmem_zips=...`) to pass the NONMEM zip files into the build without
+copying them into any image layer, keeping final image sizes lean.
+No local HTTP server is required.
+
 ### Installation
 
-* Copy your nonmem license file (named `nonmen.lic` to the same
+* Copy your nonmem license file (named `nonmem.lic`) to the same
   directory as the Dockerfile.
-* Have your NONMEM zip file password handy
-* See the instructions in the top of the Dockerfile for the command
-  to run.
-* For NONMEM, automatic download from Icon may be unreliable
-  (https://github.com/billdenney/Pharmacometrics-Docker/issues/2).
-  Manual download and serving the file from a local webserver is
-  recommended.  (See the top of the Dockerfile for instructions.)
+* Have your NONMEM zip file and its password handy.
+* Pass the zip file via `--build-context nonmem_zips=/path/to/zips`
+  (see the top of the Dockerfile for the full build command).  The zip
+  is never baked into the image.
 
 ### Running
 

--- a/build_matrix.sh
+++ b/build_matrix.sh
@@ -26,7 +26,6 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONF_FILE="${SCRIPT_DIR}/nonmem_passwords.conf"
 LOG_FILE="${SCRIPT_DIR}/build_matrix.log"
-HTTP_PORT=8888
 MAX_JOBS=16
 BUILD_ARM64=false
 
@@ -55,18 +54,15 @@ if [[ ! -f "${NONMEM_ZIP_DIR}/nonmem.lic" ]]; then
   exit 1
 fi
 
+# --- buildx pre-flight check ---
+if ! docker buildx version &>/dev/null; then
+  echo "ERROR: docker buildx is not available." >&2
+  echo "This script requires docker buildx (included with Docker 20.10+)." >&2
+  exit 1
+fi
+
 # --- ARM64 pre-flight check ---
 if [[ "${BUILD_ARM64}" == true ]]; then
-  if ! docker buildx version &>/dev/null; then
-    echo "ERROR: docker buildx is not available." >&2
-    echo "ARM64 builds require QEMU and buildx. Run:" >&2
-    echo "  sudo apt-get install qemu-user-static binfmt-support" >&2
-    echo "  docker run --privileged --rm tonistiigi/binfmt --install all" >&2
-    echo "  docker buildx create --name multiplatform --driver docker-container \\" >&2
-    echo "    --driver-opt network=host --use" >&2
-    echo "  docker buildx inspect --bootstrap" >&2
-    exit 1
-  fi
   if ! docker buildx inspect 2>/dev/null | grep -q "linux/arm64"; then
     echo "ERROR: linux/arm64 is not available in your current buildx builder." >&2
     echo "Run the ARM64 setup steps:" >&2
@@ -79,33 +75,8 @@ if [[ "${BUILD_ARM64}" == true ]]; then
   fi
 fi
 
-# --- Cleanup trap ---
-HTTP_PID=""
-cleanup() {
-  [[ -n "${HTTP_PID}" ]] && kill "${HTTP_PID}" 2>/dev/null || true
-  # nonmem.lic is left in place (it is gitignored); remove it manually if desired
-}
-trap cleanup EXIT
-
 # --- Copy license into build context ---
 cp "${NONMEM_ZIP_DIR}/nonmem.lic" "${SCRIPT_DIR}/nonmem.lic"
-
-# --- Kill any existing process on HTTP_PORT to avoid port conflict ---
-fuser -k "${HTTP_PORT}/tcp" 2>/dev/null || true
-sleep 1
-
-# --- Start local HTTP server ---
-echo "Starting HTTP server on port ${HTTP_PORT} serving ${NONMEM_ZIP_DIR} ..."
-(cd "${NONMEM_ZIP_DIR}" && python3 -m http.server "${HTTP_PORT}" --bind 127.0.0.1 \
-  >/dev/null 2>&1) &
-HTTP_PID=$!
-sleep 1  # give the server a moment to start
-
-# Verify it started
-if ! kill -0 "${HTTP_PID}" 2>/dev/null; then
-  echo "ERROR: HTTP server failed to start on port ${HTTP_PORT}" >&2
-  exit 1
-fi
 
 # --- Initialize log ---
 : > "${LOG_FILE}"
@@ -143,7 +114,7 @@ is_compatible_arm64() {
   return 0
 }
 
-# --- Parallel job tracking (by PID, not wait -n, so the HTTP server job can't interfere) ---
+# --- Parallel job tracking (by PID) ---
 declare -a build_pids=()
 
 run_build() {
@@ -172,13 +143,15 @@ for entry in "${NONMEM_VERSIONS[@]}"; do
   for ubuntu in "${AMD64_UBUNTU_VERSIONS[@]}"; do
     tag="humanpredictions/nonmem:${major}.${minor}.${patch}-ubuntu${ubuntu}-amd64"
     run_build "${tag}" \
-      docker build \
-        --network=host \
+      docker buildx build \
+        --platform linux/amd64 \
+        --load \
+        --build-context nonmem_zips="${NONMEM_ZIP_DIR}" \
         --build-arg UBUNTU_VERSION="${ubuntu}" \
         --build-arg NONMEM_MAJOR_VERSION="${major}" \
         --build-arg NONMEM_MINOR_VERSION="${minor}" \
         --build-arg NONMEM_PATCH_VERSION="${patch}" \
-        --build-arg NONMEMURL="http://127.0.0.1:${HTTP_PORT}/${zipfile}" \
+        --build-arg NONMEM_ZIPFILE="${zipfile}" \
         --build-arg NONMEMZIPPASS="${password}" \
         -t "${tag}" \
         -f "${SCRIPT_DIR}/NONMEM.Dockerfile" \
@@ -200,15 +173,15 @@ if [[ "${BUILD_ARM64}" == true ]]; then
       run_build "${tag}" \
         docker buildx build \
           --platform linux/arm64 \
-          --network=host \
+          --load \
+          --build-context nonmem_zips="${NONMEM_ZIP_DIR}" \
           --build-arg UBUNTU_VERSION="${ubuntu}" \
           --build-arg NONMEM_MAJOR_VERSION="${major}" \
           --build-arg NONMEM_MINOR_VERSION="${minor}" \
           --build-arg NONMEM_PATCH_VERSION="${patch}" \
-          --build-arg NONMEMURL="http://127.0.0.1:${HTTP_PORT}/${zipfile}" \
+          --build-arg NONMEM_ZIPFILE="${zipfile}" \
           --build-arg NONMEMZIPPASS="${password}" \
           -t "${tag}" \
-          --load \
           -f "${SCRIPT_DIR}/NONMEM.Dockerfile" \
           "${SCRIPT_DIR}"
     done
@@ -225,8 +198,6 @@ echo "" | tee -a "${LOG_FILE}"
 echo "=== Summary ===" | tee -a "${LOG_FILE}"
 successes=$(grep -c "^SUCCESS:" "${LOG_FILE}" || true)
 failures=$(grep -c "^FAILED:" "${LOG_FILE}" || true)
-skipped=$(grep -c "^SKIP" "${LOG_FILE}" || true)
 echo "Succeeded: ${successes}" | tee -a "${LOG_FILE}"
 echo "Failed:    ${failures}"  | tee -a "${LOG_FILE}"
-echo "Skipped:   ${skipped}"   | tee -a "${LOG_FILE}"
 echo "Build matrix completed at $(date)" | tee -a "${LOG_FILE}"


### PR DESCRIPTION
Replace wget + local HTTP server with BuildKit --mount=type=bind using --build-context nonmem_zips=..., eliminating the HTTP server, port conflicts, and --network=host requirement from build_matrix.sh. Also remove wget from the apt-get install since it is no longer needed.

Document in README that NONMEM 7.4.x and 7.5.0 fail on Ubuntu 22.04+ because gfortran 11+ enforces stricter Fortran standards (DO loop index redefinition, rank mismatches, type mismatches) that gfortran 9 accepted.

Correct the compatibility matrix: 7.4.4/18.04 and 7.6.0/24.04 were transient failures; both build and run correctly.