### PR TITLE
Expand build matrix to all Ubuntu × gfortran × NONMEM combinations

### DIFF
--- a/NONMEM.Dockerfile
+++ b/NONMEM.Dockerfile
@@ -9,6 +9,11 @@
 #  --build-arg NONMEM_ZIPFILE=NONMEM751.zip \
 #  -t humanpredictions/nonmem:7.5.1 \
 #  -f NONMEM.Dockerfile .
+#
+# For NONMEM 7.4.x and 7.5.0 on Ubuntu 22.04+, add:
+#  --build-arg GFORTRAN_VERSION=9
+# This installs gfortran-9 (available in standard Ubuntu 22.04/24.04 repos)
+# which is compatible with the older Fortran source in those NONMEM versions.
 
 # Set the base image to a long-term Ubuntu release
 # Override with --build-arg UBUNTU_VERSION=20.04 etc. for older NONMEM versions
@@ -18,17 +23,28 @@ FROM ubuntu:${UBUNTU_VERSION}
 # Dockerfile Maintainer
 MAINTAINER William Denney <wdenney@humanpredictions.com>
 
+# GFORTRAN_VERSION: if set (e.g. "9"), installs gfortran-9 and symlinks it as
+# the default gfortran.  Leave unset to use the Ubuntu-default gfortran.
+# Required for NONMEM 7.4.x and 7.5.0 on Ubuntu 22.04+ (gfortran 11+ is too
+# strict for those versions' Fortran source).
+ARG GFORTRAN_VERSION=""
+
 # Install:
-# gfortran,
+# gfortran (version-pinned if GFORTRAN_VERSION is set),
 # MPI,
 # and unzip
 # (then clean up the image as much as possible)
 RUN apt-get update \
+    && _GFC_PKG="${GFORTRAN_VERSION:+gfortran-${GFORTRAN_VERSION}}" \
+    && _GFC_PKG="${_GFC_PKG:-gfortran}" \
     && apt-get install --yes --no-install-recommends \
-       gfortran \
+       "${_GFC_PKG}" \
        libmpich-dev \
        mpich \
        unzip \
+    && if [ -n "${GFORTRAN_VERSION:-}" ]; then \
+           ln -sf "/usr/bin/gfortran-${GFORTRAN_VERSION}" /usr/bin/gfortran; \
+       fi \
     && rm -rf /var/lib/apt/lists/ \
               /var/cache/apt/archives/ \
               /usr/share/doc/ \

--- a/README.md
+++ b/README.md
@@ -18,72 +18,140 @@ http://www.iconplc.com/innovation/solutions/nonmem/
 
 ### Compatibility Matrix
 
-All combinations were empirically tested by building each image and
-recording success or failure.  Results below reflect actual build
-outcomes, which differ from prior documentation in several cases.
+All combinations were empirically tested by building each Docker image
+and recording success or failure.  Image tags encode the exact NONMEM
+version, Ubuntu base, gfortran version, and CPU architecture — every
+cell in the tables below corresponds to a distinct image tag.
+
+Tag format: `{NM_VERSION}-ubuntu{UBUNTU}-gfortran{GFC}-{arch}`
+Example: `7.4.1-ubuntu22.04-gfortran9-amd64`
+
+Legend: `yes` = image builds successfully · `no` = build fails ·
+`—` = gfortran version not available in that Ubuntu's standard repos
 
 #### x86-64 (linux/amd64)
 
-`yes` = image builds successfully; `no` = build fails
+##### NONMEM 7.2.0 and 7.3.0 — all gfortran versions succeed
 
-| NONMEM | 14.04 | 16.04 | 18.04 | 20.04 | 22.04 | 24.04 |
-|--------|:-----:|:-----:|:-----:|:-----:|:-----:|:-----:|
-| 7.2.0  | yes   | yes   | yes   | yes   | yes   | yes   |
-| 7.3.0  | yes   | yes   | yes   | yes   | yes   | yes   |
-| 7.4.1  | yes   | yes   | yes   | yes   | no    | no    |
-| 7.4.2  | yes   | yes   | yes   | yes   | no    | no    |
-| 7.4.3  | yes   | yes   | yes   | yes   | no    | no    |
-| 7.4.4  | yes   | yes   | yes   | yes   | no    | no    |
-| 7.5.0  | yes   | yes   | yes   | yes   | no    | no    |
-| 7.5.1  | yes   | yes   | yes   | yes   | yes   | yes   |
-| 7.6.0  | yes   | yes   | yes   | yes   | yes   | yes   |
+| gfortran | 14.04 | 16.04 | 18.04 | 20.04 | 22.04 | 24.04 |
+|:--------:|:-----:|:-----:|:-----:|:-----:|:-----:|:-----:|
+| 4.4      | yes   | —     | —     | —     | —     | —     |
+| 4.6      | yes   | —     | —     | —     | —     | —     |
+| 4.7      | yes   | yes   | —     | —     | —     | —     |
+| 4.8      | yes   | yes   | yes   | —     | —     | —     |
+| 4.9      | —     | yes   | —     | —     | —     | —     |
+| 5        | —     | yes   | yes   | —     | —     | —     |
+| 6        | —     | —     | yes   | —     | —     | —     |
+| 7        | —     | —     | yes   | yes   | —     | —     |
+| 8        | —     | —     | yes   | yes   | —     | —     |
+| 9        | —     | —     | —     | yes   | yes   | yes   |
+| 10       | —     | —     | —     | yes   | yes   | yes   |
+| 11       | —     | —     | —     | —     | yes   | yes   |
+| 12       | —     | —     | —     | —     | yes   | yes   |
+| 13       | —     | —     | —     | —     | —     | yes   |
+| 14       | —     | —     | —     | —     | —     | yes   |
 
-**Notable findings vs. prior documentation:**
+##### NONMEM 7.4.1, 7.4.2, 7.4.3, 7.4.4, and 7.5.0 — gfortran ≥ 10 fails
 
-- NONMEM 7.2.0 and 7.3.0 build successfully on *all* Ubuntu LTS
-  versions including 22.04 and 24.04.  The prior claim that NONMEM
-  older than 7.5.1 fails on Ubuntu > 20.04 applies to 7.4.x–7.5.0
-  specifically, not to 7.2.x or 7.3.x.
-- NONMEM 7.4.x and 7.5.0 fail on Ubuntu 22.04 and 24.04 because
-  gfortran 11+ (shipped in Ubuntu 22.04) enforces stricter Fortran
-  standard compliance than gfortran 9 (Ubuntu 20.04).  The NONMEM
-  7.4.x/7.5.0 Fortran source contains constructs that gfortran 9
-  accepted but gfortran 11+ rejects as errors: index variables
-  redefined inside DO loops, rank mismatches in actual arguments, and
-  INTEGER(8)/INTEGER(4) type mismatches.  NONMEM 7.5.1 and later have
-  corrected Fortran source and compile successfully with gfortran 11+.
+| gfortran | 14.04 | 16.04 | 18.04 | 20.04 | 22.04 | 24.04 |
+|:--------:|:-----:|:-----:|:-----:|:-----:|:-----:|:-----:|
+| 4.4      | yes   | —     | —     | —     | —     | —     |
+| 4.6      | yes   | —     | —     | —     | —     | —     |
+| 4.7      | yes   | yes   | —     | —     | —     | —     |
+| 4.8      | yes   | yes   | yes   | —     | —     | —     |
+| 4.9      | —     | yes   | —     | —     | —     | —     |
+| 5        | —     | yes   | yes   | —     | —     | —     |
+| 6        | —     | —     | yes   | —     | —     | —     |
+| 7        | —     | —     | yes   | yes   | —     | —     |
+| 8        | —     | —     | yes   | yes   | —     | —     |
+| 9        | —     | —     | —     | yes   | yes   | yes   |
+| 10       | —     | —     | —     | no¹   | no¹   | no¹   |
+| 11       | —     | —     | —     | —     | no¹   | no¹   |
+| 12       | —     | —     | —     | —     | no¹   | no¹   |
+| 13       | —     | —     | —     | —     | —     | no¹   |
+| 14       | —     | —     | —     | —     | —     | no¹   |
+
+##### NONMEM 7.5.1 and 7.6.0 — gfortran 4.4 fails
+
+| gfortran | 14.04 | 16.04 | 18.04 | 20.04 | 22.04 | 24.04 |
+|:--------:|:-----:|:-----:|:-----:|:-----:|:-----:|:-----:|
+| 4.4      | no²   | —     | —     | —     | —     | —     |
+| 4.6      | yes   | —     | —     | —     | —     | —     |
+| 4.7      | yes   | yes   | —     | —     | —     | —     |
+| 4.8      | yes   | yes   | yes   | —     | —     | —     |
+| 4.9      | —     | yes   | —     | —     | —     | —     |
+| 5        | —     | yes   | yes   | —     | —     | —     |
+| 6        | —     | —     | yes   | —     | —     | —     |
+| 7        | —     | —     | yes   | yes   | —     | —     |
+| 8        | —     | —     | yes   | yes   | —     | —     |
+| 9        | —     | —     | —     | yes   | yes   | yes   |
+| 10       | —     | —     | —     | yes   | yes   | yes   |
+| 11       | —     | —     | —     | —     | yes   | yes   |
+| 12       | —     | —     | —     | —     | yes   | yes   |
+| 13       | —     | —     | —     | —     | —     | yes   |
+| 14       | —     | —     | —     | —     | —     | yes   |
+
+#### Failure footnotes
+
+¹ **gfortran ≥ 10 + NONMEM 7.4.x / 7.5.0**: GCC 10 introduced stricter
+enforcement of Fortran standard compliance.  The NONMEM 7.4.x and 7.5.0
+Fortran source contains constructs that gfortran 9 (and earlier) accepted
+but gfortran 10+ rejects as hard errors: rank mismatches between actual
+arguments, INTEGER(8)/INTEGER(4) type mismatches, and index variables
+redefined inside DO loops.  NONMEM 7.5.1 corrects these issues and
+compiles cleanly with all gfortran versions.  Use gfortran 9 (e.g.,
+`-ubuntu22.04-gfortran9-amd64`) if you need NONMEM 7.4.x or 7.5.0 on a
+modern Ubuntu base.
+
+² **gfortran 4.4 + NONMEM 7.5.1 / 7.6.0**: The NONMEM 7.5.x and 7.6.x
+setup scripts pass `-ffpe-summary=none` to the Fortran compiler.  This
+flag was introduced in GCC 4.6; gfortran 4.4 does not recognize it and
+fails immediately during resource file compilation.  All gfortran versions
+≥ 4.6 succeed with NONMEM 7.5.1 and 7.6.0.
 
 #### ARM64 (linux/arm64) — Raspberry Pi 4/5 and AWS Graviton2/3/4
 
 The same `linux/arm64` Docker image runs on both Raspberry Pi 4/5 and
-AWS Graviton2/3/4; they share the same 64-bit ARM instruction set and
-no separate image is needed for Graviton.
+AWS Graviton2/3/4; they share the same 64-bit ARM instruction set and no
+separate image is needed for Graviton.
 
 NONMEM versions older than 7.5.1 are not attempted for ARM64 because
-their setup scripts contain x86-specific assumptions.  Ubuntu 14.04
-and 16.04 are also skipped because ARM toolchain support was too
-immature in those releases.
+their setup scripts contain x86-specific assumptions.  Ubuntu 14.04 and
+16.04 are also skipped because ARM toolchain support was too immature in
+those releases.
 
-| NONMEM | 18.04 | 20.04 | 22.04 | 24.04 |
-|--------|:-----:|:-----:|:-----:|:-----:|
-| 7.5.1  | no    | no    | yes   | yes   |
-| 7.6.0  | no    | no    | yes   | yes   |
+##### NONMEM 7.5.1 and 7.6.0 — arm64
 
-ARM64 builds require Ubuntu 22.04 or later; 18.04 and 20.04 fail,
-likely due to gfortran or toolchain differences in the older ARM64
-userspace.
+| gfortran | 18.04 | 20.04 | 22.04 | 24.04 |
+|:--------:|:-----:|:-----:|:-----:|:-----:|
+| 4.8      | no³   | —     | —     | —     |
+| 5        | no³   | —     | —     | —     |
+| 6        | no³   | —     | —     | —     |
+| 7        | no³   | no³   | —     | —     |
+| 8        | no³   | no³   | —     | —     |
+| 9        | —     | no³   | yes   | yes   |
+| 10       | —     | no³   | yes   | yes   |
+| 11       | —     | —     | yes   | yes   |
+| 12       | —     | —     | yes   | yes   |
+| 13       | —     | —     | —     | yes   |
+| 14       | —     | —     | —     | yes   |
+
+³ **arm64 + Ubuntu < 22.04**: ARM64 builds fail on Ubuntu 18.04 and 20.04
+regardless of gfortran version, likely due to ABI or runtime library
+differences in the older ARM64 userspace.  Ubuntu 22.04 and later work
+correctly.
 
 Raspberry Pi 3 and older (32-bit ARM, linux/arm/v7) are not supported.
 
 ### Building the Full Matrix
 
-Use `build_matrix.sh` to build all compatible combinations in parallel
-(up to 16 at a time by default):
+Use `build_matrix.sh` to build all combinations in parallel (up to 16 at
+a time by default):
 
-    # amd64 only (54 combinations)
+    # amd64 only (243 combinations)
     ./build_matrix.sh
 
-    # amd64 + arm64 (62 combinations; requires buildx + QEMU — see script header)
+    # amd64 + arm64 (281 combinations; requires buildx + QEMU — see script header)
     ./build_matrix.sh --arm64
 
     # Control parallelism

--- a/build_matrix.sh
+++ b/build_matrix.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# build_matrix.sh — build NONMEM Docker images across Ubuntu LTS × NONMEM versions
+# build_matrix.sh — build NONMEM Docker images across Ubuntu LTS × NONMEM × gfortran versions
 #
 # Usage:
 #   ./build_matrix.sh [--arm64] [--jobs N]
@@ -10,7 +10,7 @@
 #
 # Prerequisites:
 #   1. Copy nonmem_passwords.conf.example to nonmem_passwords.conf and fill in values.
-#   2. Place nonmem.lic in /home/bill/tmp/nonmem/ (or set NONMEM_ZIP_DIR in the conf file).
+#   2. Place nonmem.lic in NONMEM_ZIP_DIR (set in the conf file).
 #
 # ARM64 prerequisites (one-time setup on an x86-64 host):
 #   sudo apt-get install qemu-user-static binfmt-support
@@ -19,7 +19,10 @@
 #     --driver-opt network=host --use
 #   docker buildx inspect --bootstrap
 #
-# Results are written to build_matrix.log in the current directory.
+# Tag format: {NM_VERSION}-ubuntu{UBUNTU}-gfortran{GFC}-{arch}
+# Example:    7.5.1-ubuntu24.04-gfortran13-amd64
+#
+# Results are written to build_matrix.log in the script directory.
 
 set -euo pipefail
 
@@ -103,6 +106,17 @@ AMD64_UBUNTU_VERSIONS=(14.04 16.04 18.04 20.04 22.04 24.04)
 # Ubuntu LTS versions for arm64 builds (14.04/16.04 skipped: ARM toolchain too immature)
 ARM64_UBUNTU_VERSIONS=(18.04 20.04 22.04 24.04)
 
+# gfortran versions available in standard repos (no PPA) per Ubuntu release.
+# Sourced empirically from apt-cache search on each Ubuntu version.
+declare -A UBUNTU_GFORTRAN_VERSIONS=(
+  ["14.04"]="4.4 4.6 4.7 4.8"
+  ["16.04"]="4.7 4.8 4.9 5"
+  ["18.04"]="4.8 5 6 7 8"
+  ["20.04"]="7 8 9 10"
+  ["22.04"]="9 10 11 12"
+  ["24.04"]="9 10 11 12 13 14"
+)
+
 # For ARM64, only attempt NONMEM 7.5.1+ (older versions have x86-specific setup scripts)
 is_compatible_arm64() {
   local major=$1 minor=$2 patch=$3
@@ -131,7 +145,7 @@ run_build() {
 
   # Throttle: when at the cap, wait for the oldest build to free a slot
   if (( ${#build_pids[@]} >= MAX_JOBS )); then
-    wait "${build_pids[0]}" || true   # subshell always exits 0; || true is safety net
+    wait "${build_pids[0]}" || true
     build_pids=("${build_pids[@]:1}")
   fi
 }
@@ -141,21 +155,24 @@ echo "=== amd64 builds ===" | tee -a "${LOG_FILE}"
 for entry in "${NONMEM_VERSIONS[@]}"; do
   read -r major minor patch zipfile password <<< "${entry}"
   for ubuntu in "${AMD64_UBUNTU_VERSIONS[@]}"; do
-    tag="humanpredictions/nonmem:${major}.${minor}.${patch}-ubuntu${ubuntu}-amd64"
-    run_build "${tag}" \
-      docker buildx build \
-        --platform linux/amd64 \
-        --load \
-        --build-context nonmem_zips="${NONMEM_ZIP_DIR}" \
-        --build-arg UBUNTU_VERSION="${ubuntu}" \
-        --build-arg NONMEM_MAJOR_VERSION="${major}" \
-        --build-arg NONMEM_MINOR_VERSION="${minor}" \
-        --build-arg NONMEM_PATCH_VERSION="${patch}" \
-        --build-arg NONMEM_ZIPFILE="${zipfile}" \
-        --build-arg NONMEMZIPPASS="${password}" \
-        -t "${tag}" \
-        -f "${SCRIPT_DIR}/NONMEM.Dockerfile" \
-        "${SCRIPT_DIR}"
+    for gfc in ${UBUNTU_GFORTRAN_VERSIONS["${ubuntu}"]}; do
+      tag="humanpredictions/nonmem:${major}.${minor}.${patch}-ubuntu${ubuntu}-gfortran${gfc}-amd64"
+      run_build "${tag}" \
+        docker buildx build \
+          --platform linux/amd64 \
+          --load \
+          --build-context nonmem_zips="${NONMEM_ZIP_DIR}" \
+          --build-arg UBUNTU_VERSION="${ubuntu}" \
+          --build-arg NONMEM_MAJOR_VERSION="${major}" \
+          --build-arg NONMEM_MINOR_VERSION="${minor}" \
+          --build-arg NONMEM_PATCH_VERSION="${patch}" \
+          --build-arg NONMEM_ZIPFILE="${zipfile}" \
+          --build-arg NONMEMZIPPASS="${password}" \
+          --build-arg GFORTRAN_VERSION="${gfc}" \
+          -t "${tag}" \
+          -f "${SCRIPT_DIR}/NONMEM.Dockerfile" \
+          "${SCRIPT_DIR}"
+    done
   done
 done
 
@@ -169,21 +186,24 @@ if [[ "${BUILD_ARM64}" == true ]]; then
       continue
     fi
     for ubuntu in "${ARM64_UBUNTU_VERSIONS[@]}"; do
-      tag="humanpredictions/nonmem:${major}.${minor}.${patch}-ubuntu${ubuntu}-arm64"
-      run_build "${tag}" \
-        docker buildx build \
-          --platform linux/arm64 \
-          --load \
-          --build-context nonmem_zips="${NONMEM_ZIP_DIR}" \
-          --build-arg UBUNTU_VERSION="${ubuntu}" \
-          --build-arg NONMEM_MAJOR_VERSION="${major}" \
-          --build-arg NONMEM_MINOR_VERSION="${minor}" \
-          --build-arg NONMEM_PATCH_VERSION="${patch}" \
-          --build-arg NONMEM_ZIPFILE="${zipfile}" \
-          --build-arg NONMEMZIPPASS="${password}" \
-          -t "${tag}" \
-          -f "${SCRIPT_DIR}/NONMEM.Dockerfile" \
-          "${SCRIPT_DIR}"
+      for gfc in ${UBUNTU_GFORTRAN_VERSIONS["${ubuntu}"]}; do
+        tag="humanpredictions/nonmem:${major}.${minor}.${patch}-ubuntu${ubuntu}-gfortran${gfc}-arm64"
+        run_build "${tag}" \
+          docker buildx build \
+            --platform linux/arm64 \
+            --load \
+            --build-context nonmem_zips="${NONMEM_ZIP_DIR}" \
+            --build-arg UBUNTU_VERSION="${ubuntu}" \
+            --build-arg NONMEM_MAJOR_VERSION="${major}" \
+            --build-arg NONMEM_MINOR_VERSION="${minor}" \
+            --build-arg NONMEM_PATCH_VERSION="${patch}" \
+            --build-arg NONMEM_ZIPFILE="${zipfile}" \
+            --build-arg NONMEMZIPPASS="${password}" \
+            --build-arg GFORTRAN_VERSION="${gfc}" \
+            -t "${tag}" \
+            -f "${SCRIPT_DIR}/NONMEM.Dockerfile" \
+            "${SCRIPT_DIR}"
+      done
     done
   done
 fi


### PR DESCRIPTION
- Add GFORTRAN_VERSION build-arg to NONMEM.Dockerfile; installs the specified gfortran package and symlinks it as /usr/bin/gfortran so SETUP scripts always receive the plain 'gfortran' name they require
- Restructure build_matrix.sh into a triple loop (NONMEM × Ubuntu × gfortran) covering all versions available in standard repos without PPAs; 243 amd64 combinations attempted, 196 succeed
- Change image tag format to include gfortran version: {NM_VERSION}-ubuntu{UBUNTU}-gfortran{GFC}-{arch}
- Rewrite README compatibility matrix as per-NONMEM-version tables with documented failure footnotes: ¹ gfortran ≥ 10 + NONMEM 7.4.x/7.5.0 (stricter Fortran compliance) ² gfortran 4.4 + NONMEM 7.5.1/7.6.0 (-ffpe-summary=none not supported) ³ arm64 + Ubuntu < 22.04 (ARM toolchain/ABI issues)
- All 196 successful amd64 images pushed to ECR